### PR TITLE
ci: scope push trigger to master so same-repo bot PRs run CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+    branches: [master]
   pull_request:
 env:
   NODE_VERSION: "22"
@@ -8,7 +9,6 @@ env:
   ETHERPAD_DOMAIN: "${{ secrets.ETHERPAD_DOMAIN }}"
 jobs:
   test:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,6 @@ jobs:
       - name: Test
         run: pnpm test
   test-snapshot:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +41,6 @@ jobs:
       - name: Test
         run: pnpm test:snapshot
   build:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +57,6 @@ jobs:
       - name: Build
         run: pnpm run build
   check:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +73,6 @@ jobs:
       - name: Check
         run: pnpm run check
   typescript:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +89,6 @@ jobs:
       - name: Check types
         run: pnpm run check:ts
   lint:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +105,6 @@ jobs:
       - name: Run eslint
         run: pnpm run lint
   formatting:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +121,6 @@ jobs:
       - name: Check formatting
         run: pnpm prettier --check .
   outdated:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -144,7 +137,6 @@ jobs:
       - name: Check outdated
         run: pnpm outdated
   knip:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Scope the `push` trigger in `.github/workflows/ci.yaml` to `branches: [master]` and remove the per-job `if: github.event_name == 'push' || github.event.pull_request.head.repo.fork` gate.

## Why

The old gate existed to avoid duplicate CI runs (both `push` and `pull_request` fire on feature branches in the same repo). It worked for human PRs, but it skipped CI entirely on same-repo PRs opened by bots — most visibly the auto-generated [#634 chore: update snapshots](https://github.com/beeminder/blog/pull/634), where every job shows up as `skipped`. Two reasons that PR has no CI:

1. The branch was pushed by `github-actions[bot]` using `GITHUB_TOKEN`, which by design does not trigger downstream workflows (recursion prevention). So no `push` event fires.
2. The `pull_request` event does fire, but `head.repo.fork == false`, so the `if:` gate is false on every job and they all skip.

Scoping the trigger instead of gating the jobs avoids the duplicate-run problem without that blind spot:

- Push to a feature branch → no `push` event (only `master` is in the list), only `pull_request` runs CI. No duplicate.
- Push to `master` post-merge → `push` runs CI. No PR exists at that point.
- Fork PRs and same-repo bot PRs → `pull_request` runs CI. No more skips.

## Test plan

- [ ] CI runs on this PR (this is the test — if everything is `skipped` again, the change didn't take effect).
- [ ] After merge, verify the next push to `master` triggers CI.
- [ ] After merge, the next auto-generated `chore/update-snapshots` PR shows real check results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)