### PR TITLE
refactor: split post validation schema from content processing

### DIFF
--- a/src/lib/getPosts.ts
+++ b/src/lib/getPosts.ts
@@ -48,7 +48,7 @@ const makePosts = memoize((): Promise<Post>[] =>
       if (!result.success) {
         throw new Error(
           `Failed to parse post ${d.source}: ${result.error.message}`,
-          result.error,
+          { cause: result.error },
         );
       }
       return processPost(result.data);

--- a/src/lib/getPosts.ts
+++ b/src/lib/getPosts.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import memoize from "./memoize";
-import { type Post, post } from "../schemas/post";
+import { type Post, processPost, rawPost } from "../schemas/post";
 import fetchPosts from "./fetchPosts";
 import readSources from "./readSources";
 
@@ -44,12 +44,14 @@ function writePostsCache(hash: string, posts: Post[]): void {
 const makePosts = memoize((): Promise<Post>[] =>
   fetchPosts().map((p) =>
     p.then((d) => {
-      const result = post.safeParse(d);
-      if (result.success) return result.data;
-      throw new Error(
-        `Failed to parse post ${d.source}: ${result.error.message}`,
-        result.error,
-      );
+      const result = rawPost.safeParse(d);
+      if (!result.success) {
+        throw new Error(
+          `Failed to parse post ${d.source}: ${result.error.message}`,
+          result.error,
+        );
+      }
+      return processPost(result.data);
     }),
   ),
 );

--- a/src/schemas/post.spec.ts
+++ b/src/schemas/post.spec.ts
@@ -5,7 +5,9 @@ import ether from "../lib/test/ether";
 // Minimal valid metadata for the rawPost schema. Tests that need to
 // exercise validation should override individual fields rather than
 // constructing full Etherpad-format markdown.
-function meta(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function meta(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     source: "the_url",
     date: "2020-01-01",

--- a/src/schemas/post.spec.ts
+++ b/src/schemas/post.spec.ts
@@ -1,653 +1,96 @@
 import { describe, it, expect } from "vitest";
-import { post } from "./post";
+import { rawPost, processPost } from "./post";
 import ether from "../lib/test/ether";
-import meta from "../lib/test/meta";
 
-describe("post", () => {
-  it("requires disqus id", () => {
-    const md = ether({
-      frontmatter: meta({
-        disqus_id: "",
-        date: new Date(),
-      }),
-    });
+// Minimal valid metadata for the rawPost schema. Tests that need to
+// exercise validation should override individual fields rather than
+// constructing full Etherpad-format markdown.
+function meta(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    source: "the_url",
+    date: "2020-01-01",
+    excerpt: "the_excerpt",
+    slug: "the_slug",
+    tags: ["the_tag"],
+    redirects: ["the_redirect"],
+    author: "the_author",
+    status: "publish",
+    disqus_id: "the_disqus_id",
+    md: "ignored by rawPost",
+    ...overrides,
+  };
+}
 
-    const data = {
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "",
-      md,
-    };
-
-    expect(() => post.parse(data)).toThrowError();
+describe("rawPost", () => {
+  it("accepts a complete metadata object", () => {
+    const result = rawPost.safeParse(meta());
+    expect(result.success).toBe(true);
   });
 
-  it("uses disqus id", () => {
-    const md = ether();
-
-    const p = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "test-post",
-      md,
-    });
-
-    expect(p.disqus_id).toEqual("test-post");
+  it("requires source", () => {
+    const result = rawPost.safeParse(meta({ source: undefined }));
+    expect(result.success).toBe(false);
   });
 
-  it("does not include private notes in excerpts", async () => {
-    const md = ether({
-      before: "private notes",
-    });
-
-    const p = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(p.excerpt).not.toContain("private notes");
+  it("requires non-empty source", () => {
+    const result = rawPost.safeParse(meta({ source: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("does not include raw markdown in excerpts", async () => {
-    const md = ether({
-      content: "[link](#)",
-    });
-
-    const p = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(p.excerpt).not.toContain("(#)");
+  it("requires slug", () => {
+    const result = rawPost.safeParse(meta({ slug: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("does not use image from private notes", async () => {
-    const md = ether({
-      before: "<img src='/private' />",
-    });
-
-    const p = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(p.image).toBeUndefined();
+  it("requires author", () => {
+    const result = rawPost.safeParse(meta({ author: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires title", async () => {
-    const md = ether({
-      title: null,
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires disqus_id", () => {
+    const result = rawPost.safeParse(meta({ disqus_id: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires slug", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires date", () => {
+    const result = rawPost.safeParse(meta({ date: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires author", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires status to be a known value", () => {
+    const result = rawPost.safeParse(meta({ status: "" }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires disqus_id", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires excerpt", () => {
+    const result = rawPost.safeParse(meta({ excerpt: undefined }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires redirects", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: undefined,
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires tags", () => {
+    const result = rawPost.safeParse(meta({ tags: undefined }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires date", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires redirects", () => {
+    const result = rawPost.safeParse(meta({ redirects: undefined }));
+    expect(result.success).toBe(false);
   });
 
-  it("requires tags", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: undefined,
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+  it("requires md", () => {
+    const result = rawPost.safeParse(meta({ md: undefined }));
+    expect(result.success).toBe(false);
   });
+});
 
-  it("requires status", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("requires source", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: undefined,
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("requires new line preceeding HTML comments", async () => {
-    const md = ether({
-      content: `This is the paragraph in question
-<!-- comment --> More text`,
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("specifies error reason", async () => {
-    const md = ether({
-      content: `This is the paragraph in question
-<!-- comment --> More text`,
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    if (result.success) {
-      throw new Error("Expected error");
-    }
-
-    expect(JSON.stringify(result.error)).toEqual(
-      expect.stringMatching(/comment syntax error/),
-    );
-  });
-
-  it("requires excerpt", async () => {
-    const md = ether();
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: undefined,
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("expects excerpt from MAGIC_AUTO_EXTRACT to be Generated", async () => {
-    const md = ether({
-      content: "words",
-    });
-
-    const result = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "MAGIC_AUTO_EXTRACT",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.excerpt).toContain("word");
-  });
-
-  it("expects custom excerpt to return unchanged", async () => {
-    const md = ether();
-
-    const result = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.excerpt).toMatch("the excerpt");
-  });
-
-  it("extracts image title", async () => {
-    const md = ether({
-      content: `<img src="https://blog.beeminder.com/image.png" title="the_title" />`,
-    });
-
-    const result = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.image?.title).toMatch("the_title");
-  });
-
-  it("extracts image alt", async () => {
-    const md = ether({
-      content: `<img src="https://blog.beeminder.com/image.png" alt="the_alt" />`,
-    });
-
-    const result = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.image?.alt).toMatch("the_alt");
-  });
-
-  it("extracts image alt and title", async () => {
-    const md = ether({
-      content: `<img src="https://blog.beeminder.com/image.png" alt="the_alt" title="the_title" />`,
-    });
-
-    const result = post.parse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.image).toEqual(
-      expect.objectContaining({ title: "the_title", alt: "the_alt" }),
-    );
-  });
-
-  it("does not accept date from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        date: "2020-01-01",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept date_string from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        date_string: "2020-01-01",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept excerpt from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        excerpt: "the_excerpt",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept slug from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        slug: "the_slug",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept author from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        author: "the_author",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept tags from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        tags: ["the_tag"],
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept disqus_id from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        disqus_id: "the_disqus_id",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      status: "publish",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept status from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        status: "publish",
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      redirects: ["the_redirect"],
-      author: "the_author",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
-  });
-
-  it("does not accept redirects from frontmatter", async () => {
-    const md = ether({
-      frontmatter: meta({
-        redirects: ["the_redirect"],
-      }),
-    });
-
-    const result = post.safeParse({
-      source: "the_url",
-      date: "2020-01-01",
-      excerpt: "the_excerpt",
-      slug: "the_slug",
-      tags: ["the_tag"],
-      author: "the_author",
-      status: "publish",
-      disqus_id: "the_disqus_id",
-      md,
-    });
-
-    expect(result.success).toEqual(false);
+// A small integration-style check: rawPost + processPost together
+// reproduce the seam used by getPosts. Detailed processing assertions
+// live in processPost.spec.ts.
+describe("schema + processPost integration", () => {
+  it("produces a Post when given valid input", () => {
+    const raw = rawPost.parse(meta({ md: ether() }));
+    const result = processPost(raw);
+    expect(result.disqus_id).toEqual("the_disqus_id");
+    expect(result.slug).toEqual("the_slug");
   });
 });

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -7,76 +7,87 @@ import extractImage from "../lib/extractImage";
 import { dateString } from "./dateString";
 import { cachedParseMarkdown } from "../lib/cachedParseMarkdown";
 
-export const post = z
-  .object({
-    source: z.string(),
-    title: z.string().optional(),
-    slug: z.string(),
-    date: z.string(),
-    author: z.string(),
-    tags: z.array(z.string()),
-    status: z.string(),
-    disqus_id: z.string(),
-    excerpt: z.string(),
-    redirects: z.array(z.string()),
-    md: z.string(),
-  })
-  .transform(({ source: url, md, ...rest }, ctx) => {
-    const content = md;
+// RawPost: validates the metadata shape of an input post.
+// Intentionally does NOT do any markdown parsing or content processing —
+// that work belongs to processPost(). Keeping this schema pure makes
+// validation tests trivial and lets callers obtain validated metadata
+// without paying for the full content pipeline.
+export const rawPost = z.object({
+  source: z.string().min(1),
+  title: z.string().optional(),
+  slug: z.string().min(1),
+  date: z.string().min(1),
+  author: z.string().min(1),
+  tags: z.array(z.string()),
+  status: status,
+  disqus_id: z.string().min(1),
+  excerpt: z.string(),
+  redirects: z.array(z.string()),
+  md: z.string(),
+});
 
-    let c;
+export type RawPost = z.infer<typeof rawPost>;
 
-    try {
-      c = cachedParseMarkdown(content);
-    } catch (error) {
-      ctx.addIssue({
-        path: ["md"],
-        message: `Failed to parse post ${url}`,
-        code: "custom",
-        params: {
-          error: error instanceof Error ? error.message : "Unknown error",
-        },
-      });
-      return z.NEVER;
-    }
-
-    const date = rest.date && new Date(rest.date);
-    const dateStringResult = dateString.safeParse(date);
-
-    if (rest.title) {
-      throw new Error(
-        `(${url}) : Title is not allowed in posts.json. Specify in markdown only. "BEGIN_MAGIC[The-Post-Name-Here]"`,
-      );
-    }
-
-    return {
-      ...rest,
-      tags: rest.tags?.filter(Boolean),
-      excerpt: getExcerpt(rest.excerpt, c),
-      image: extractImage(c),
-      title: parseTitle(md),
-      date,
-      date_string: dateStringResult.success && dateStringResult.data,
-      content: c,
-      md,
-    };
-  })
-  .pipe(
-    z.object({
-      content: z.string(),
-      excerpt: z.string(),
-      slug: z.string().min(1),
-      image: image.or(z.undefined()),
-      title: z.string(),
-      tags: z.array(z.string()),
-      redirects: z.array(z.string()),
-      date: z.date(),
-      date_string: z.string(),
-      author: z.string().min(1),
-      status: status,
-      disqus_id: z.string().min(1),
-      md: z.string(),
-    }),
-  );
+// Output shape of a fully processed post — same as the previous schema
+// output. Kept as a Zod schema so consumers can still validate processed
+// posts (e.g. when reading from cache) and so the inferred Post type
+// stays in sync.
+export const post = z.object({
+  content: z.string(),
+  excerpt: z.string(),
+  slug: z.string().min(1),
+  image: image.or(z.undefined()),
+  title: z.string(),
+  tags: z.array(z.string()),
+  redirects: z.array(z.string()),
+  date: z.date(),
+  date_string: z.string(),
+  author: z.string().min(1),
+  status: status,
+  disqus_id: z.string().min(1),
+  md: z.string(),
+});
 
 export type Post = z.infer<typeof post>;
+
+// processPost: turns a validated RawPost into a fully processed Post.
+// Owns the content pipeline (markdown parse, title extraction, excerpt
+// computation, first-image extraction, date conversion). This is the
+// single place where content-processing concerns live.
+export function processPost(raw: RawPost): Post {
+  const { source: url, md, title: rawTitle, ...rest } = raw;
+
+  if (rawTitle) {
+    throw new Error(
+      `(${url}) : Title is not allowed in posts.json. Specify in markdown only. "BEGIN_MAGIC[The-Post-Name-Here]"`,
+    );
+  }
+
+  let content: string;
+  try {
+    content = cachedParseMarkdown(md);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(`Failed to parse post ${url}: ${message}`);
+  }
+
+  const date = new Date(rest.date);
+  const dateStringResult = dateString.safeParse(date);
+
+  const processed = {
+    ...rest,
+    tags: rest.tags?.filter(Boolean),
+    excerpt: getExcerpt(rest.excerpt, content),
+    image: extractImage(content),
+    title: parseTitle(md),
+    date,
+    date_string: dateStringResult.success ? dateStringResult.data : undefined,
+    content,
+    md,
+  };
+
+  // Run the processed object through `post` so the output shape and
+  // invariants (e.g. title required, image schema, status enum) are
+  // enforced at exactly one seam, just like before.
+  return post.parse(processed);
+}

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -32,7 +32,7 @@ export type RawPost = z.infer<typeof rawPost>;
 // output. Kept as a Zod schema so consumers can still validate processed
 // posts (e.g. when reading from cache) and so the inferred Post type
 // stays in sync.
-export const post = z.object({
+const post = z.object({
   content: z.string(),
   excerpt: z.string(),
   slug: z.string().min(1),

--- a/src/schemas/post.ts
+++ b/src/schemas/post.ts
@@ -68,11 +68,12 @@ export function processPost(raw: RawPost): Post {
     content = cachedParseMarkdown(md);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    throw new Error(`Failed to parse post ${url}: ${message}`);
+    throw new Error(`Failed to parse post ${url}: ${message}`, {
+      cause: error,
+    });
   }
 
   const date = new Date(rest.date);
-  const dateStringResult = dateString.safeParse(date);
 
   const processed = {
     ...rest,
@@ -81,7 +82,7 @@ export function processPost(raw: RawPost): Post {
     image: extractImage(content),
     title: parseTitle(md),
     date,
-    date_string: dateStringResult.success ? dateStringResult.data : undefined,
+    date_string: dateString.parse(date),
     content,
     md,
   };

--- a/src/schemas/processPost.spec.ts
+++ b/src/schemas/processPost.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { processPost, rawPost, type RawPost } from "./post";
+import ether from "../lib/test/ether";
+
+// Builds a valid RawPost. Tests focus on processPost behavior and
+// don't need to exercise validation, so we construct via the schema
+// once to satisfy the type, then override fields directly.
+function rawWith(overrides: Partial<RawPost> = {}): RawPost {
+  const base = rawPost.parse({
+    source: "the_url",
+    date: "2020-01-01",
+    excerpt: "the_excerpt",
+    slug: "the_slug",
+    tags: ["the_tag"],
+    redirects: ["the_redirect"],
+    author: "the_author",
+    status: "publish",
+    disqus_id: "the_disqus_id",
+    md: ether(),
+  });
+  return { ...base, ...overrides };
+}
+
+describe("processPost", () => {
+  it("parses markdown into HTML content", () => {
+    const result = processPost(rawWith({ md: ether({ content: "hello" }) }));
+    expect(result.content).toContain("hello");
+  });
+
+  it("extracts the title from BEGIN_MAGIC", () => {
+    const result = processPost(rawWith({ md: ether({ title: "My Title" }) }));
+    expect(result.title).toEqual("My Title");
+  });
+
+  it("rejects when markdown lacks a title", () => {
+    expect(() =>
+      processPost(rawWith({ md: ether({ title: null }) })),
+    ).toThrow();
+  });
+
+  it("throws when title is set in frontmatter (posts.json)", () => {
+    expect(() =>
+      processPost(rawWith({ title: "from-posts-json" } as Partial<RawPost>)),
+    ).toThrow(/Title is not allowed in posts.json/);
+  });
+
+  it("returns a custom excerpt unchanged", () => {
+    const result = processPost(rawWith({ excerpt: "the excerpt" }));
+    expect(result.excerpt).toEqual("the excerpt");
+  });
+
+  it("expands MAGIC_AUTO_EXTRACT into a generated excerpt", () => {
+    const result = processPost(
+      rawWith({
+        excerpt: "MAGIC_AUTO_EXTRACT",
+        md: ether({ content: "words" }),
+      }),
+    );
+    expect(result.excerpt).toContain("word");
+  });
+
+  it("excludes private notes from auto-extracted excerpts", () => {
+    const result = processPost(
+      rawWith({
+        excerpt: "MAGIC_AUTO_EXTRACT",
+        md: ether({ before: "private notes", content: "public" }),
+      }),
+    );
+    expect(result.excerpt).not.toContain("private notes");
+  });
+
+  it("does not include raw markdown in auto-extracted excerpts", () => {
+    const result = processPost(
+      rawWith({
+        excerpt: "MAGIC_AUTO_EXTRACT",
+        md: ether({ content: "[link](#)" }),
+      }),
+    );
+    expect(result.excerpt).not.toContain("(#)");
+  });
+
+  it("extracts the first image from content", () => {
+    const result = processPost(
+      rawWith({
+        md: ether({
+          content: `<img src="https://example.com/image.png" alt="the_alt" title="the_title" />`,
+        }),
+      }),
+    );
+    expect(result.image).toEqual(
+      expect.objectContaining({
+        src: "https://example.com/image.png",
+        alt: "the_alt",
+        title: "the_title",
+      }),
+    );
+  });
+
+  it("does not use images from private notes", () => {
+    const result = processPost(
+      rawWith({
+        md: ether({ before: "<img src='/private' />" }),
+      }),
+    );
+    expect(result.image).toBeUndefined();
+  });
+
+  it("converts the date string to a Date object", () => {
+    const result = processPost(rawWith({ date: "2020-01-01" }));
+    expect(result.date).toBeInstanceOf(Date);
+    expect(result.date_string).toEqual("2020-01-01");
+  });
+
+  it("throws on markdown with comment syntax errors", () => {
+    expect(() =>
+      processPost(
+        rawWith({
+          md: ether({
+            content: `This is the paragraph in question
+<!-- comment --> More text`,
+          }),
+        }),
+      ),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

The Zod schema in `src/schemas/post.ts` was simultaneously a validator and a full content-processing pipeline. Its `.transform()` parsed markdown, extracted the title from `BEGIN_MAGIC[...]`, computed the excerpt, and extracted the first image. Tests had to construct full Etherpad-format markdown just to check that a `slug` is required, and callers couldn't get raw validated data without paying for the whole pipeline.

This PR separates concerns:

- **`rawPost`** — validates input metadata shape only (no transforms that do markdown work).
- **`processPost(raw: RawPost) -> Post`** — owns the content-processing pipeline (markdown parse, title extraction, excerpt computation, first-image extraction, date conversion).
- **`getPosts`** — the single assembly point that composes them.

The public-facing `Post` type is unchanged, so all consumers (components, pages, scripts) continue to work without modification.

## Changes

- `src/schemas/post.ts` — split into `rawPost` schema, `Post` output schema, and `processPost()` function.
- `src/lib/getPosts.ts` — now calls `rawPost.safeParse(d)` then `processPost(result.data)`.
- `src/schemas/post.spec.ts` — schema tests simplified: no longer construct Etherpad markdown for metadata-only validation.
- `src/schemas/processPost.spec.ts` — new file with focused tests for the content-processing pipeline.

The integration test surface is preserved by `getPosts.spec.ts` (existing) plus a small integration smoke test in `post.spec.ts`.

Closes #640

## Test plan

- [x] `pnpm test --run` — all 93 unit tests pass.
- [x] `pnpm check:ts` — clean.
- [x] `pnpm lint` — clean.
- [ ] `pnpm test:snapshot` and `pnpm build` require `ETHERPAD_DOMAIN` env var to fetch real post content; both fail on master with the same error in this sandbox, so this is pre-existing infrastructure (not a regression). CI should run them with the proper environment.
- [ ] Visual diff via snapshot tests in CI to confirm rendered output is byte-identical.

## Notes

- Sibling issues #641 (consolidate excerpt logic) and #642 (cache abstraction) are intentionally out of scope. The excerpt and cache code was moved into `processPost` as-is, not refactored further.
- One small, intentional behavior tweak: `rawPost` enforces `min(1)` on `source` (it was previously `z.string()`). This was already a required field in practice (validated downstream), so this just surfaces the failure earlier.