### PR TITLE
Quiet the expected ENOENT in image-cache script

### DIFF
--- a/scripts/image-cache.mjs
+++ b/scripts/image-cache.mjs
@@ -12,7 +12,13 @@ let files = [];
 try {
   files = readdirSync(folderPath, "utf8");
 } catch (e) {
-  console.warn(e);
+  if (e.code === "ENOENT") {
+    // First build on a clean checkout — astro hasn't populated its image
+    // cache yet, so there's nothing to extend. Quiet, expected case.
+    console.log(`image-cache: no astro cache yet at ${folderPath}, skipping`);
+  } else {
+    console.warn(`image-cache: failed to read ${folderPath}:`, e);
+  }
 }
 
 for (const file of files.filter((f) => f.endsWith(".json"))) {


### PR DESCRIPTION
## Summary
- \`scripts/image-cache.mjs\` calls \`readdirSync\` on the astro asset cache folder; on a clean checkout (e.g. fresh Render build) that folder doesn't exist yet and \`readdirSync\` throws \`ENOENT\`.
- The current \`console.warn(e)\` dumps the full Error object including stack trace, which makes build logs look like something failed even though the script catches and continues.
- This PR treats \`ENOENT\` as the expected first-build case and logs a single info line; other error codes still log loudly so we don't hide a real problem.

## Test plan
- [x] Manual: run with a missing folder → "image-cache: no astro cache yet at … skipping", exit 0
- [x] Manual: point at an existing non-directory file (\`ENOTDIR\`) → loud warning with the error, exit 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)