### PR TITLE
Extract cache-trust decision into a cachePolicy seam

### DIFF
--- a/src/lib/cachePolicy.spec.ts
+++ b/src/lib/cachePolicy.spec.ts
@@ -6,7 +6,7 @@ describe("isPersistentCacheEnabled", () => {
     vi.unstubAllEnvs();
   });
 
-  it("is enabled when neither RENDER nor FILE_SYSTEM_CACHE is set", () => {
+  it("is enabled when RENDER and FILE_SYSTEM_CACHE are unset/empty", () => {
     vi.stubEnv("RENDER", "");
     vi.stubEnv("FILE_SYSTEM_CACHE", "");
 
@@ -32,7 +32,7 @@ describe("isPersistentCacheEnabled", () => {
     expect(isPersistentCacheEnabled()).toBe(false);
   });
 
-  it("stays enabled for other FILE_SYSTEM_CACHE values", () => {
+  it("stays enabled when FILE_SYSTEM_CACHE is set to a non-false value", () => {
     vi.stubEnv("RENDER", "");
     vi.stubEnv("FILE_SYSTEM_CACHE", "true");
 

--- a/src/lib/cachePolicy.spec.ts
+++ b/src/lib/cachePolicy.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { isPersistentCacheEnabled } from "./cachePolicy";
+
+describe("isPersistentCacheEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("is enabled when neither RENDER nor FILE_SYSTEM_CACHE is set", () => {
+    vi.stubEnv("RENDER", "");
+    vi.stubEnv("FILE_SYSTEM_CACHE", "");
+
+    expect(isPersistentCacheEnabled()).toBe(true);
+  });
+
+  it("is disabled on Render", () => {
+    vi.stubEnv("RENDER", "true");
+
+    expect(isPersistentCacheEnabled()).toBe(false);
+  });
+
+  it("is disabled when FILE_SYSTEM_CACHE is false", () => {
+    vi.stubEnv("FILE_SYSTEM_CACHE", "false");
+
+    expect(isPersistentCacheEnabled()).toBe(false);
+  });
+
+  it("stays enabled for other FILE_SYSTEM_CACHE values", () => {
+    vi.stubEnv("RENDER", "");
+    vi.stubEnv("FILE_SYSTEM_CACHE", "true");
+
+    expect(isPersistentCacheEnabled()).toBe(true);
+  });
+});

--- a/src/lib/cachePolicy.spec.ts
+++ b/src/lib/cachePolicy.spec.ts
@@ -25,6 +25,13 @@ describe("isPersistentCacheEnabled", () => {
     expect(isPersistentCacheEnabled()).toBe(false);
   });
 
+  it("disables on Render even when FILE_SYSTEM_CACHE is true", () => {
+    vi.stubEnv("RENDER", "true");
+    vi.stubEnv("FILE_SYSTEM_CACHE", "true");
+
+    expect(isPersistentCacheEnabled()).toBe(false);
+  });
+
   it("stays enabled for other FILE_SYSTEM_CACHE values", () => {
     vi.stubEnv("RENDER", "");
     vi.stubEnv("FILE_SYSTEM_CACHE", "true");

--- a/src/lib/cachePolicy.ts
+++ b/src/lib/cachePolicy.ts
@@ -6,9 +6,12 @@ import env from "./env";
 // persist across builds?
 //
 // On Render the build directory can persist across deploys, so a stale cache
-// would silently serve old pad content; `FILE_SYSTEM_CACHE=false` is a manual
-// local override for the same situation (e.g. regenerating snapshots after a
-// pad edit). In both cases we must NOT trust persistent caches.
+// would silently serve old pad content. This bites hardest with the getPosts
+// disk cache, which is keyed on the posts.json hash — that key does not change
+// when a pad body is edited, so a persisted hit would never re-fetch.
+// `FILE_SYSTEM_CACHE=false` is a manual local override for the same situation
+// (e.g. regenerating snapshots after a pad edit). In both cases we must NOT
+// trust persistent caches.
 export function isPersistentCacheEnabled(): boolean {
   return !env("RENDER") && env("FILE_SYSTEM_CACHE") !== "false";
 }

--- a/src/lib/cachePolicy.ts
+++ b/src/lib/cachePolicy.ts
@@ -1,0 +1,14 @@
+import env from "./env";
+
+// One decision drives two caches: the node-fetch-cache backend used when
+// fetching pads (in `fetchPost`) and the processed-posts disk cache (in
+// `getPosts`). The question both ask is the same — can we trust caches that
+// persist across builds?
+//
+// On Render the build directory can persist across deploys, so a stale cache
+// would silently serve old pad content; `FILE_SYSTEM_CACHE=false` is a manual
+// local override for the same situation (e.g. regenerating snapshots after a
+// pad edit). In both cases we must NOT trust persistent caches.
+export function isPersistentCacheEnabled(): boolean {
+  return !env("RENDER") && env("FILE_SYSTEM_CACHE") !== "false";
+}

--- a/src/lib/fetchPost.ts
+++ b/src/lib/fetchPost.ts
@@ -1,22 +1,16 @@
 import NodeFetchCache, { FileSystemCache, MemoryCache } from "node-fetch-cache";
 import memoize from "./memoize";
 import canonicalizeUrl from "./canonicalizeUrl";
-import env from "./env";
+import { isPersistentCacheEnabled } from "./cachePolicy";
 import { recordFetchAttempt, recordCacheMiss } from "./buildPerf";
 
-const RENDER = env("RENDER");
-const FILE_SYSTEM_CACHE = env("FILE_SYSTEM_CACHE");
-
-const IS_RENDER = !!RENDER;
-const IS_FILE_SYSTEM_CACHE_DISABLED = FILE_SYSTEM_CACHE === "false";
-
 function buildCache() {
-  if (IS_RENDER || IS_FILE_SYSTEM_CACHE_DISABLED) {
-    console.info("Using in-memory cache");
-    return new MemoryCache();
-  } else {
+  if (isPersistentCacheEnabled()) {
     console.info("Using file-system cache");
     return new FileSystemCache();
+  } else {
+    console.info("Using in-memory cache");
+    return new MemoryCache();
   }
 }
 

--- a/src/lib/getPosts.ts
+++ b/src/lib/getPosts.ts
@@ -3,17 +3,10 @@ import memoize from "./memoize";
 import { type Post, processPost, rawPost } from "../schemas/post";
 import fetchPosts from "./fetchPosts";
 import readSources from "./readSources";
-import env from "./env";
+import { isPersistentCacheEnabled } from "./cachePolicy";
 import { hashCache } from "./hashCache";
 
 const POSTS_CACHE_FILE = ".cache/posts-processed.json";
-
-// The disk cache is keyed on posts.json contents, which do not change when pad
-// content changes. On Render the build directory can persist across deploys,
-// so a cache hit would silently serve stale pad content.
-function isDiskCacheDisabled(): boolean {
-  return !!env("RENDER") || env("FILE_SYSTEM_CACHE") === "false";
-}
 
 const getDuplicates = (
   arr: Array<Record<string, unknown>>,
@@ -68,7 +61,7 @@ async function computeAllPosts(): Promise<Post[]> {
 }
 
 const getAllPosts = memoize((): Promise<Post[]> => {
-  if (isDiskCacheDisabled()) return computeAllPosts();
+  if (!isPersistentCacheEnabled()) return computeAllPosts();
 
   return hashCache<Post[]>({
     key: getSourcesHash(),


### PR DESCRIPTION
## What

Both `fetchPost` (which picks the `node-fetch-cache` backend) and `getPosts` (which gates the processed-posts disk cache) were independently re-deriving the same decision — *can we trust caches that persist across builds?* — by separately reading `RENDER` and `FILE_SYSTEM_CACHE` in two different phrasings.

This moves that decision behind a single `isPersistentCacheEnabled()` predicate in a new `src/lib/cachePolicy.ts`.

## Why

- **Locality** — the meaning of `RENDER` / `FILE_SYSTEM_CACHE` now lives in one module instead of being re-derived in two.
- **Leverage** — callers ask one named question instead of repeating boolean logic.
- **Testability** — the predicate is the test surface (`cachePolicy.spec.ts`), exercised via `vi.stubEnv` rather than reasoning about global env in two larger modules.

## Behavioral equivalence

Pure refactor — verified equivalent at both call sites:
- `getPosts`: old `!isDiskCacheDisabled()` = `!RENDER && FSC!=="false"` = new `isPersistentCacheEnabled()`.
- `fetchPost`: old in-memory condition `!!RENDER || FSC==="false"` is the exact negation of the new file-system condition.

The only timing change: `fetchPost` previously read env into module-level consts at import; it now reads inside the (memoized) `buildCache()`. Env is stable during a build, so behavior is unchanged — and this is what makes the policy unit-testable.

The posts.json-keying rationale (the documented root cause behind the Render cache bypass, commit `db8e7cd`) is preserved in the `cachePolicy.ts` comment.

## Tests

`pnpm test` (122 passing incl. new `cachePolicy.spec.ts`), `pnpm check:ts`, and eslint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)