### PR TITLE
Extract tag-slug canonicalisation into one module

### DIFF
--- a/src/lib/getRedirects.ts
+++ b/src/lib/getRedirects.ts
@@ -1,4 +1,5 @@
 import readSources from "./readSources";
+import { normalizeTagName, tagRedirectSlug } from "./tagSlug";
 
 export default async function getRedirects(): Promise<Record<string, string>> {
   const sources = readSources();
@@ -18,15 +19,14 @@ export default async function getRedirects(): Promise<Record<string, string>> {
   // Build tag redirects from posts.json tag arrays (no fetch needed)
   const tagNames = [
     ...new Set(
-      sources
-        .flatMap((p) => (p.tags as string[]) ?? [])
-        .map((t) => t.toLowerCase()),
+      sources.flatMap((p) => (p.tags as string[]) ?? []).map(normalizeTagName),
     ),
   ];
   const tagRedirects: Record<string, string> = {};
   for (const tag of tagNames) {
-    if (tag.includes(" ")) {
-      tagRedirects[`/tags/${tag.replace(/ /g, "+")}`] = `/tags/${tag}`;
+    const encoded = tagRedirectSlug(tag);
+    if (encoded) {
+      tagRedirects[`/tags/${encoded}`] = `/tags/${tag}`;
     }
     tagRedirects[`/tag/${tag}`] = `/tags/${tag}`;
   }

--- a/src/lib/getTags.ts
+++ b/src/lib/getTags.ts
@@ -1,6 +1,7 @@
 import type { Post } from "../schemas/post";
 import getPosts from "./getPosts";
 import memoize from "./memoize";
+import { normalizeTagName, tagRedirectSlug } from "./tagSlug";
 
 type Tag = {
   name: string;
@@ -20,18 +21,18 @@ async function makeTags(): Promise<Tag[]> {
       posts
         .map((p) => p.tags)
         .flat()
-        .map((t) => t.toLowerCase()),
+        .map(normalizeTagName),
     ),
   ];
   const tags = tagNames.map((t) => {
     const matched = posts.filter((p) =>
-      p.tags.some((pt) => pt.toLowerCase() === t),
+      p.tags.some((pt) => normalizeTagName(pt) === t),
     );
     return {
       name: t,
       posts: matched,
       count: matched.length,
-      redirect: t.includes(" ") ? t.replace(/ /g, "+") : null,
+      redirect: tagRedirectSlug(t),
     };
   });
 

--- a/src/lib/tagSlug.spec.ts
+++ b/src/lib/tagSlug.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTagName, tagRedirectSlug } from "./tagSlug";
+
+describe("normalizeTagName", () => {
+  it("lowercases the tag name", () => {
+    expect(normalizeTagName("Commitment Devices")).toEqual(
+      "commitment devices",
+    );
+  });
+
+  it("leaves an already-lowercase name unchanged", () => {
+    expect(normalizeTagName("akrasia")).toEqual("akrasia");
+  });
+});
+
+describe("tagRedirectSlug", () => {
+  it("encodes spaces as +", () => {
+    expect(tagRedirectSlug("commitment devices")).toEqual("commitment+devices");
+  });
+
+  it("encodes every space", () => {
+    expect(tagRedirectSlug("a b c")).toEqual("a+b+c");
+  });
+
+  it("returns null when there is nothing to encode", () => {
+    expect(tagRedirectSlug("akrasia")).toBeNull();
+  });
+});

--- a/src/lib/tagSlug.ts
+++ b/src/lib/tagSlug.ts
@@ -1,0 +1,17 @@
+// Tag-name canonicalisation, shared by the tag listing (getTags) and the
+// redirect table (getRedirects). Both modules need the same two rules — tags
+// are matched case-insensitively, and a space in a tag name is encoded as "+"
+// in its URL — so they live here in one place and cannot drift apart.
+
+/** Canonical, case-insensitive form of a tag name. */
+export function normalizeTagName(tag: string): string {
+  return tag.toLowerCase();
+}
+
+/**
+ * The "+"-encoded slug for a tag, or `null` when the tag needs no encoding
+ * (i.e. it contains no spaces, so its slug already equals its name).
+ */
+export function tagRedirectSlug(tag: string): string | null {
+  return tag.includes(" ") ? tag.replace(/ /g, "+") : null;
+}


### PR DESCRIPTION
## What

The rule for turning a tag name into a slug — lowercase it, and encode spaces as `+` — was implemented independently in two places:

- `getTags` — its `redirect` field: `t.includes(" ") ? t.replace(/ /g, "+") : null`
- `getRedirects` — its `/tags/...` entries: `if (tag.includes(" ")) ... tag.replace(/ /g, "+")`

Plus the lowercasing (`t.toLowerCase()`) was duplicated in both.

This moves both rules behind `normalizeTagName()` and `tagRedirectSlug()` in a new `src/lib/tagSlug.ts`, consumed by both modules.

## Why

The two implementations could drift, and a bug in one wouldn't be caught by the other's tests. Now there's **one rule, one place to fix, one test surface** (`tagSlug.spec.ts`).

## Behavioral equivalence

Pure refactor:
- `tagRedirectSlug(tag)` is byte-for-byte the old ternary; it returns a non-empty string exactly when `tag.includes(" ")` is true, so `if (encoded)` is identical to the old `if (tag.includes(" "))`.
- `normalizeTagName` is exactly `tag.toLowerCase()`, applied at every original call site (including the case-insensitive `some()` comparison in `getTags`).
- The earlier lowercase-normalisation fix (route-collision prevention) is fully preserved.

## Tests

`pnpm test` (125 passing incl. new `tagSlug.spec.ts`), `pnpm check:ts`, eslint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)