### PR TITLE
Enable Dependabot and drop the outdated CI check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,22 +120,6 @@ jobs:
         run: pnpm install
       - name: Check formatting
         run: pnpm prettier --check .
-  outdated:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-      - name: Install
-        run: pnpm install
-      - name: Check outdated
-        run: pnpm outdated
   knip:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

- Add `.github/dependabot.yml` enabling Dependabot for two ecosystems:
  - **npm** — grouped into a single weekly PR
  - **github-actions** — grouped into a single weekly PR
- Remove the `outdated` job from `ci.yaml`, which ran `pnpm outdated`.

## Why

The `outdated` CI job failed the build whenever any dependency was behind, which is noisy and doesn't actually do anything about it. Dependabot owns dependency-freshness signalling properly — it opens PRs with the actual upgrades — so the CI gate is redundant. Grouping keeps the PR volume low (one npm PR + one actions PR per week rather than one per dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)