### PR TITLE
fix: restore missing space before author in post byline

### DIFF
--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -26,7 +26,7 @@ const {
     title={post.title}
     href={linkTitle ? `/${post.slug}` : undefined}
   >
-    {post.date_string} {strings.postMeta.byline} <a
+    {post.date_string}{" "}{strings.postMeta.byline}{" "}<a
       href={`/authors/${post.author}`}>{post.author}</a
     >
   </TitleLockup>


### PR DESCRIPTION
## Problem

Since #667 the post byline renders the author with **no space after "by"** — e.g. `January 1, 2021 • bybsoule` instead of `… • by bsoule`. Visible on every post listing and post page.

## Cause

Extracting the byline into the i18n catalog lengthened the JSX line, so Prettier wrapped the `<a>` opening tag across multiple lines. Astro trims whitespace that sits adjacent to a wrapped element tag, so the single space between `{strings.postMeta.byline}` and the author `<a>` was dropped at build time.

## Fix

Use explicit `{" "}` expressions for the inter-token spaces in the byline, so they render regardless of how the tag is wrapped — the canonical JSX fix for this. One line in `PostMeta.astro`; no copy/catalog change.

```
{post.date_string}{" "}{strings.postMeta.byline}{" "}<a …>{post.author}</a>
```

Verified: `pnpm lint`, `astro check` (0 errors), and `pnpm test` (131) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)