### PR TITLE
Visual-regression tooling: page scoping + repoint pixelteer to PinePeakDigital

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "knip": "^6.13.1",
     "lint-staged": "^17.0.4",
     "pixelmatch": "^7.2.0",
-    "pixelteer": "github:narthur/pixelteer",
+    "pixelteer": "github:pinepeakdigital/pixelteer",
     "pngjs": "^7.0.0",
     "prettier": "3.8.3",
     "puppeteer": "24.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       pixelteer:
-        specifier: github:narthur/pixelteer
-        version: https://codeload.github.com/narthur/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3(puppeteer@24.43.1(typescript@6.0.3))
+        specifier: github:pinepeakdigital/pixelteer
+        version: https://codeload.github.com/pinepeakdigital/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3(puppeteer@24.43.1(typescript@6.0.3))
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2676,8 +2676,8 @@ packages:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
 
-  pixelteer@https://codeload.github.com/narthur/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3:
-    resolution: {tarball: https://codeload.github.com/narthur/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3}
+  pixelteer@https://codeload.github.com/pinepeakdigital/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3:
+    resolution: {tarball: https://codeload.github.com/pinepeakdigital/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3}
     version: 1.0.0
     peerDependencies:
       puppeteer: ^22.6.5
@@ -6350,7 +6350,7 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  pixelteer@https://codeload.github.com/narthur/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3(puppeteer@24.43.1(typescript@6.0.3)):
+  pixelteer@https://codeload.github.com/pinepeakdigital/pixelteer/tar.gz/4f4e26f9abb2981a1dad3e0f5b8b078835c9ceb3(puppeteer@24.43.1(typescript@6.0.3)):
     dependencies:
       pixelmatch: 5.3.0
       pngjs: 7.0.0
@@ -6631,7 +6631,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5

--- a/scripts/puppeteer.ts
+++ b/scripts/puppeteer.ts
@@ -17,7 +17,33 @@ const server = await preview({
 });
 
 const urls = await getSitemap();
-const paths = urls.map((url) => new URL(url).pathname + "?snap");
+
+// Optional flags for targeted runs (default behaviour: compare every sitemap URL):
+//   --detail      restrict to blog post detail pages (single-segment slugs)
+//   --limit=N     cap the number of paths compared
+const detailOnly = process.argv.includes("--detail");
+const limitArg = process.argv.find((a) => a.startsWith("--limit="));
+const limit = limitArg ? Number(limitArg.split("=")[1]) : Infinity;
+
+const SECTION_ROOTS = new Set(["tags", "authors", "page"]);
+const isDetailPage = (pathname: string): boolean => {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length !== 1) return false; // home, archives, /tags/x, etc.
+  const [segment] = segments;
+  if (SECTION_ROOTS.has(segment)) return false; // /tags, /authors, /page
+  if (/^\d{4}$/.test(segment)) return false; // /YYYY year archive
+  return true;
+};
+
+const pathnames = urls.map((url) => new URL(url).pathname);
+const selected = (
+  detailOnly ? pathnames.filter(isDetailPage) : pathnames
+).slice(0, limit);
+const paths = selected.map((pathname) => pathname + "?snap");
+
+console.log(
+  `Comparing ${paths.length} path(s)${detailOnly ? " (detail pages only)" : ""}.`,
+);
 
 await compareUrls({
   baseUrl1: base,

--- a/scripts/puppeteer.ts
+++ b/scripts/puppeteer.ts
@@ -23,13 +23,21 @@ const urls = await getSitemap();
 //   --limit=N     cap the number of paths compared
 const detailOnly = process.argv.includes("--detail");
 const limitArg = process.argv.find((a) => a.startsWith("--limit="));
-const limit = limitArg ? Number(limitArg.split("=")[1]) : Infinity;
+let limit = Infinity;
+if (limitArg) {
+  const parsed = Number(limitArg.slice("--limit=".length));
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `Invalid --limit value: "${limitArg.split("=")[1]}". Use a positive integer.`,
+    );
+  }
+  limit = parsed;
+}
 
 const SECTION_ROOTS = new Set(["tags", "authors", "page"]);
 const isDetailPage = (pathname: string): boolean => {
-  const segments = pathname.split("/").filter(Boolean);
-  if (segments.length !== 1) return false; // home, archives, /tags/x, etc.
-  const [segment] = segments;
+  const [segment, ...rest] = pathname.split("/").filter(Boolean);
+  if (!segment || rest.length > 0) return false; // home, archives, /tags/x, etc.
   if (SECTION_ROOTS.has(segment)) return false; // /tags, /authors, /page
   if (/^\d{4}$/.test(segment)) return false; // /YYYY year archive
   return true;


### PR DESCRIPTION
## Why

Spun out of checking #667 (i18n string extraction) for rendering regressions on blog detail pages. Two small, related changes to the visual-regression tooling:

1. **Page scoping for `scripts/puppeteer.ts`** — the pixelteer comparison previously ran against all ~951 sitemap URLs. Added optional flags so a targeted run is possible:
   - `--detail` — restrict to blog post detail pages (single-segment slugs; excludes the home page, `/tags`, `/authors`, `/page`, and `/YYYY[/MM]` archives).
   - `--limit=N` — cap the number of paths compared (must be a positive integer; throws otherwise).

   Default behaviour (compare every sitemap URL) is unchanged.

2. **Repoint the `pixelteer` dependency** — the package was transferred from `narthur/pixelteer` to `PinePeakDigital/pixelteer`. GitHub redirects the old path, but the dependency is now pinned to the new owner directly (same commit SHA, identical content) so we don't rely on the redirect.

## Notes

- This is the small, mergeable slice. The broader visual-regression hardening (fixing pixelteer's RGBA crash, structured output, dynamic-region masking, browser pinning, etc.) is tracked in #669.
- Opened as **draft**.

## Test plan

- `pnpm check:ts` — clean
- `pnpm exec eslint scripts/puppeteer.ts` — clean
- `pnpm test` — 131 passed
- Manually ran `pnpm puppeteer --detail --limit=5` against a local build vs. production: 5 detail pages compared, no chrome regressions from #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
