### PR TITLE
fix(visual-regression): pass base URL into getSitemap

### DIFF
--- a/scripts/puppeteer.ts
+++ b/scripts/puppeteer.ts
@@ -16,7 +16,7 @@ const server = await preview({
   },
 });
 
-const urls = await getSitemap();
+const urls = await getSitemap(compare);
 
 // Optional flags for targeted runs (default behaviour: compare every sitemap URL):
 //   --detail      restrict to blog post detail pages (single-segment slugs)

--- a/src/lib/test/getSitemap.ts
+++ b/src/lib/test/getSitemap.ts
@@ -1,5 +1,7 @@
-export default async function getSitemap(): Promise<string[]> {
-  const response = await fetch(`http://localhost:4321/sitemap-0.xml`);
+export default async function getSitemap(
+  base = "http://localhost:4321",
+): Promise<string[]> {
+  const response = await fetch(`${base}/sitemap-0.xml`);
   if (!response.ok) {
     throw new Error(`Failed to fetch sitemap: ${response.statusText}`);
   }


### PR DESCRIPTION
Closes the last open item in #669 (item 3 — port collision).

`getSitemap()` hardcoded `http://localhost:4321`, the same port `scripts/puppeteer.ts` hardcodes for `preview()`. The two agreed only by coincidence; if 4321 were taken or the preview port changed, the sitemap fetch would silently point at the wrong server.

This threads the preview URL through instead: `getSitemap(base = "http://localhost:4321")` and `puppeteer.ts` passes its existing `compare` URL. Default preserves current behaviour; the preview port is now a single source of truth.

review-loop: 6 agents, 0 findings. 131 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)