### PR TITLE
fix: resolve render.yaml vs Blueprint drift (#657)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,8 @@ services:
   - type: web
     name: beeblog
     env: static
-    buildCommand: pnpm install --frozen-lockfile && pnpm run build
+    # Install runs via the $RENDER-gated `prebuild` hook in package.json (single source of truth). See #657.
+    buildCommand: pnpm run build
     staticPublishPath: ./dist
     pullRequestPreviewsEnabled: true
     routes:


### PR DESCRIPTION
Closes #657.

Reverts `render.yaml`'s `buildCommand` back to `pnpm run build` so the file matches the live (unsynced) Blueprint. Install responsibility stays solely in the `$RENDER`-gated `prebuild` hook in `package.json` — the thing that actually keeps deploys green today.

This is **option 2** from the issue: single source of truth in `package.json`, portable to any static host, and requires no Render dashboard sync. Anyone reading `render.yaml` can now predict what runs on Render without knowing the Blueprint sync state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)