### PR TITLE
chore(deps): stop Dependabot offering TypeScript 7.0 major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # TS 7.0 is the native "tsgo" rewrite; @typescript-eslint and Astro's
+      # check tooling crash on it. Drop when the ecosystem supports it.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for TypeScript major-version bumps.

## Why

The grouped npm bump (#757) pulls **TypeScript 7.0.2** — the native "tsgo" rewrite. `@typescript-eslint@8.63` and Astro's `check` tooling both crash on it:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree/.../create-program/shared.js
```

This breaks the `lint` and `check` CI jobs. Ignoring the major keeps 6.x updates flowing until the ecosystem supports TS 7.0.

## Follow-up

Once this is on `master`, comment `@dependabot recreate` on #757 to rebuild the group PR without the TS 7.0 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)